### PR TITLE
Add CODEOWNERS and dummy CI integration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,14 @@
+stages:
+  - compile
+
+variables:
+  PROJECT_NAME: algorithmia-r
+  DOCKER_HOST: tcp://docker:2375/
+  DOCKER_DRIVER: overlay2
+  RUNNING_ON_BUILD_SERVER: "true"
+
+compile:compile:
+  stage: compile
+  image: alpine
+  script:
+  - echo "dummy compile"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# https://github.blog/2017-07-06-introducing-code-owners/
+
+*   @algorithmiaio/developer-technologies-contractors


### PR DESCRIPTION
DevTech team is now the code owner of the repository; all changes will be authored (or at least approved) by them.

Also added a dummy CI build configuration for DevTech team to build upon.