### PR TITLE
Update for successful CRAN submission

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,3 +3,4 @@
 ^\.gitlab-ci\.yml$
 ^CODEOWNERS$
 ^.*tar\.gz.*$
+^README.*

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: algorithmia
 Type: Package
 Title: Allows you to Easily Interact with the Algorithmia Platform
-Version: 0.3.0
+Version: 0.3.1
 Date: 2020-09-28
 Author: James Sutton, James Athappilly, Taylor Raack
 Maintainer: Robert Fulton <rfulton@algorithmia.com>

--- a/README.md
+++ b/README.md
@@ -30,14 +30,19 @@ result <- response$result
 
 ## Deployment
 
-### New feature release without breaking API changes
-
-* Verify that the `Version` field in the [DESCRIPTION](DESCRIPTION) file has had its minor release version (y in x.y.z incremented from the previously released version, and that the patch version (z in x.y.z) is set to `0`.
+* Verify that the `Version` field in the [DESCRIPTION](DESCRIPTION) file has had its version updated per proper [semantic versioning](https://semver.org/) from [the previous version in CRAN](https://cran.r-project.org/web/packages/algorithmia/index.html)
 * Ensure that CI build passes successfully
-* Run `R CMD build .`
+* Inside a Docker container with the image for that stage with the local directory bind-mounted (ex: `docker run -it --rm -v `pwd`:/algorithmia-r <docker image from .gitlab-ci.yml>`)
+  * `cd /algorithmia-r`
+  * Run all commands `test:check_as_cran` CI stage defined in `.gitlab-ci.yml`
 * Verify that the submission follows [all CRAN policies](https://cran.r-project.org/web/packages/policies.html).
 * Submit the new package https://xmpalantir.wu.ac.at/cransubmit/
   * Name: Robert Fulton
   * Email: rfulton@algorithmia.com
   * Package: <the `tar.gz` file that was created from the build>
   * Optional comment: <leave blank>
+* Monitor email to rfulton@algorithmia.com for any CRAN emails
+  * At the very least, an email should come through asking to confirm the submission. This must be done before the submission will appear in CRAN.
+* Wait for the version of [the library in CRAN](https://cran.r-project.org/web/packages/algorithmia/index.html) is updated with the changes submitted
+* Create a new Git tag on the commit submitted to CRAN. This should include the major, minor, and patch versions (ex: `0.3.0`).
+* Push any Git tags / release branches up to Github.

--- a/tools/test-cran-package
+++ b/tools/test-cran-package
@@ -24,11 +24,9 @@ Rscript -e "chooseCRANmirror(graphics=FALSE, ind=1) ; install.packages('rjson') 
 # Make the man pages
 Rscript -e "chooseCRANmirror(graphics=FALSE, ind=1) ; install.packages('roxygen2') ; roxygen2::roxygenise()"
 
-# Let's remove the tests from the package for now
+# Update the license file to CRAN license format (different from standard open-source license format)
 tempDir=$(mktemp -d)
 cp LICENSE $tempDir
-
-# Temporarily switch to expected CRAN license format (different from standard open-source license format)
 year=$(date +"%Y")
 printf "YEAR: $year\nCOPYRIGHT HOLDER: Algorithmia" > LICENSE
 

--- a/tools/test-cran-package
+++ b/tools/test-cran-package
@@ -34,3 +34,6 @@ printf "YEAR: $year\nCOPYRIGHT HOLDER: Algorithmia" > LICENSE
 mkdir -p ~/.local/share/rhub
 echo '"rfulton@algorithmia.com","d770f2b180504d23a55a8d89e43c9f97"' >> ~/.local/share/rhub/validated_emails.csv
 Rscript tools/check-rhub.r "cran"
+
+# if everything works ok, build the package locally
+R CMD build .


### PR DESCRIPTION
* Create package ready for submission at the end of a successful CRAN test submission
* Updated CRAN submission instructions after going through a successful submission
* Remove README from CRAN submission as it's for Algorithmia engineers (documentation about the library is auto-generated by the CRAN processes in PDF format directly from sources and comments)
* Bump patch version for next submission (prevents errors in CRAN testing)